### PR TITLE
Allow custom tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ with:
   tagging: true
 ```
 
+### custom tag
+
+Use `tag` to push an additional image, which is tagged with the custom value.
+This can be useful for whenthe action is triggered from refs/heads/master, but you want to tag with a specific value.
+
+```yaml
+with:
+  name: myDocker/repository
+  username: ${{ secrets.DOCKER_USERNAME }}
+  password: ${{ secrets.DOCKER_PASSWORD }}
+  tagging: true
+  tag: ${{ steps.tag.outputs.result }} # eg: 0.6.0
+```
+
 ### snapshot
 Use `snapshot` to push an additional image, which is tagged with {YEAR}{MONTH}{DAY}{HOUR}{MINUTE}{SECOND}{first 6 digits of the git sha}.  
 The date was inserted to prevent new builds with external dependencies override older builds with the same sha.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,6 +54,9 @@ if [ "${INPUT_SNAPSHOT}" == "true" ]; then
   docker push ${SHA_DOCKER_NAME}
 elif [ "${INPUT_TAGGING}" == "true" ]; then
   DOCKER_TAG=$(echo ${GITHUB_REF} | sed -e 's/refs\/tags\/v//')
+  if [ ! -z "${INPUT_TAG}" ]; then
+    DOCKER_TAG="${INPUT_TAG}"
+  fi
   docker build $BUILDPARAMS -t ${INPUT_NAME}:latest -t ${INPUT_NAME}:${DOCKER_TAG} .
   docker push ${INPUT_NAME}:latest
   docker push ${INPUT_NAME}:${DOCKER_TAG}

--- a/test.sh
+++ b/test.sh
@@ -196,6 +196,28 @@ Called mock with: logout"
   cleanEnvironment
 }
 
+function itUsesCustomTagIfTaggingConfigured() {
+  export GITHUB_REF='refs/tags/v0.5.0'
+  export INPUT_USERNAME='USERNAME'
+  export INPUT_PASSWORD='PASSWORD'
+  export INPUT_NAME='my/repository'
+  export INPUT_TAGGING='true'
+  export INPUT_TAG='0.6.0'
+  export INPUT_DOCKERFILE='MyDockerFileName'
+  local result=$(exec /entrypoint.sh)
+  local expected="Called mock with: login -u USERNAME --password-stdin
+Called mock with: build -f MyDockerFileName -t my/repository:latest -t my/repository:0.6.0 .
+Called mock with: push my/repository:latest
+Called mock with: push my/repository:0.6.0
+Called mock with: logout"
+  if [ "$result" != "$expected" ]; then
+    echo "Expected: $expected
+    Got: $result"
+    exit 1
+  fi
+  cleanEnvironment
+}
+
 function itLogsIntoAnotherRegistryIfConfigured() {
   export GITHUB_REF='refs/tags/myRelease'
   export INPUT_USERNAME='USERNAME'
@@ -279,6 +301,7 @@ itPushesBranchByShaAndDateInAddition
 itCachesImageFromFormerBuildAndUsesItForSnapshotIfConfigured
 itPushesBranchByShaAndDateInAdditionWithSpecificDockerfile
 itCachesImageFromFormerBuildAndUsesItTaggingIfConfigured
+itUsesCustomTagIfTaggingConfigured
 itLogsIntoAnotherRegistryIfConfigured
 itCachesImageFromFormerBuildIfConfigured
 itErrorsWhenNameWasNotSet


### PR DESCRIPTION
In my case, I automatically bump my git semver on pushes to master (eg: after pull request).

The git checkout action only does a shallow clone, so I have to fetch tags too so I can find what I set it to in a previous job.

This PR adds the ability to specify the tag explicitly.

**Alternatives**:
- Do the fetch of tags, and use `git-describe` instead of `GITHUB_REF`
- Allow a list of custom tags